### PR TITLE
use migrations even when db is being seeded

### DIFF
--- a/src/openiddict-test/Migrations/DatabaseInitializer.cs
+++ b/src/openiddict-test/Migrations/DatabaseInitializer.cs
@@ -18,7 +18,7 @@ namespace openiddicttest
 
         public async Task Seed()
         {
-            _context.Database.EnsureCreated();
+            _context.Database.Migrate();
 
             // Add Mvc.Client to the known applications.
             if (_context.Applications.Any())


### PR DESCRIPTION
.EnsureCreated() uses the model, rather than applying migrations.  So when you later add a migration, and try to apply it, it starts from the beginning and confuses everyone.
